### PR TITLE
Switch from poetry to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ pytest = "^5.1.2"
 tox = "^3.21.4"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 skip_string_normalization = true


### PR DESCRIPTION
[poetry-core](https://pypi.org/project/poetry-core/) replaces poetry as the build backend, while poetry remains as the build front-end. I'm creating this patch as part of some work I'm doing cleaning up packaging in [nixpkgs](https://github.com/NixOS/nixpkgs).